### PR TITLE
feat: Migrate from async to sync produce with batching

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -73,19 +74,19 @@ func leaveAndResetOffsets(ctx context.Context, cl *kgo.Client, cfg ConsumerGroup
 // Also waits for topics to catch up to the messages in case it is lagging behind.
 func resetOffsets(ctx context.Context, cl *kgo.Client, cfg ConsumerGroupCfg, offsets map[string]map[int32]kgo.EpochOffset, l *slog.Logger) error {
 	var (
-		backOff = retryBackoff()
-		//maxAttempts = 10
-		attempts = 0
-		admCl    = kadm.NewClient(cl)
+		backOff     = retryBackoff()
+		maxAttempts = 1 // TODO: make this configurable?
+		attempts    = 0
+		admCl       = kadm.NewClient(cl)
 	)
 	defer admCl.Close()
 
 	// wait for topic lap to catch up
 waitForTopicLag:
 	for {
-		// if attempts >= maxAttempts {
-		// 	return fmt.Errorf("max attempts(%d) for fetching offsets", maxAttempts)
-		// }
+		if attempts >= maxAttempts {
+			return fmt.Errorf("max attempts(%d) for fetching offsets", maxAttempts)
+		}
 
 		l.Debug("fetching end offsets", "topics", cfg.Topics)
 

--- a/config.go
+++ b/config.go
@@ -86,7 +86,8 @@ type ProducerCfg struct {
 	// Upper bound of max message bytes to produce
 	MaxMessageBytes int `koanf:"max_message_bytes"`
 	// Buffer produce messages
-	BatchSize int `koanf:"batch_size"`
+	BatchSize      int `koanf:"batch_size"`
+	FlushBatchSize int `koanf:"flush_batch_size"`
 	// compression
 	Compression string `koanf:"compression"` // gzip/snappy/lz4/zstd/none
 

--- a/consumer.go
+++ b/consumer.go
@@ -90,9 +90,6 @@ func (m *consumerManager) setTopicOffsets(rec *kgo.Record) {
 		Offset: rec.Offset + 1,
 	}
 
-	m.Lock()
-	defer m.Unlock()
-
 	// keep offsets in memory
 	if m.c.offsets != nil {
 		if o, ok := m.c.offsets[rec.Topic]; ok {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
 	flag "github.com/spf13/pflag"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 var (
@@ -121,11 +122,14 @@ func main() {
 	}
 
 	relay := relay{
-		consumerMgr: m,
-		producer:    p,
-		topics:      cfg.Topics,
-		metrics:     metrics.NewSet(),
-		logger:      logger,
+		consumerMgr:     m,
+		producer:        p,
+		producerBatchCh: make(chan *kgo.Record, cfg.Producer.BatchSize),
+		producerBatch:   make([]*kgo.Record, 0, cfg.Producer.BatchSize),
+
+		topics:  cfg.Topics,
+		metrics: metrics.NewSet(),
+		logger:  logger,
 
 		maxRetries:     cfg.App.MaxFailovers,
 		retryBackoffFn: retryBackoff(),

--- a/producer.go
+++ b/producer.go
@@ -8,6 +8,7 @@ import (
 
 type producer struct {
 	client *kgo.Client
+	cfg    ProducerCfg
 
 	logger *slog.Logger
 }
@@ -18,6 +19,8 @@ func initProducer(cfg ProducerCfg, l *slog.Logger) (*producer, error) {
 	prod := &producer{logger: l}
 	opts := []kgo.Opt{
 		kgo.AllowAutoTopicCreation(),
+		kgo.ProduceRequestTimeout(cfg.SessionTimeout),
+		kgo.RecordDeliveryTimeout(cfg.SessionTimeout), // break the :ProduceSync if it takes too long
 		kgo.RequestRetries(cfg.MaxRetries),
 		kgo.ProducerBatchMaxBytes(int32(cfg.MaxMessageBytes)),
 		kgo.MaxBufferedRecords(cfg.BatchSize),
@@ -70,5 +73,6 @@ func initProducer(cfg ProducerCfg, l *slog.Logger) (*producer, error) {
 	}
 
 	prod.client = client
+	prod.cfg = cfg
 	return prod, nil
 }

--- a/relay.go
+++ b/relay.go
@@ -26,6 +26,9 @@ type relay struct {
 	consumerMgr *consumerManager
 	producer    *producer
 
+	producerBatchCh chan *kgo.Record
+	producerBatch   []*kgo.Record
+
 	topics  map[string]string
 	metrics *metrics.Set
 	logger  *slog.Logger
@@ -49,6 +52,9 @@ type relay struct {
 
 // Start starts the consumer loop on kafka (A), fetch messages and relays over to kafka (B) using an async producer.
 func (r *relay) Start(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	if err := r.validateOffsets(ctx); err != nil {
 		return err
 	}
@@ -60,6 +66,19 @@ func (r *relay) Start(ctx context.Context) error {
 		go r.trackTopicLag(ctx, wg)
 	}
 
+	// start producer worker
+	wg.Add(1)
+	go func() {
+		if err := r.startProducerWorker(ctx, wg); err != nil {
+			r.logger.Error("error starting producer worker", "err", err)
+		}
+
+		// producer worker exited because there is no active upstream; cancel the context to exit the consumer loop.
+		if ctx.Err() != context.Canceled {
+			cancel()
+		}
+	}()
+
 	// Flush the producer after the poll loop is over.
 	defer func() {
 		if err := r.producer.client.Flush(ctx); err != nil {
@@ -67,6 +86,15 @@ func (r *relay) Start(ctx context.Context) error {
 		}
 	}()
 
+	r.startConsumerWorker(ctx)
+
+	wg.Wait()
+
+	return nil
+}
+
+// startConsumerWorker starts the consumer worker which polls the kafka cluster for messages.
+func (r *relay) startConsumerWorker(ctx context.Context) error {
 pollLoop:
 	for {
 		// exit if max retries is exhausted
@@ -168,31 +196,161 @@ pollLoop:
 					continue
 				}
 
-				msg := &kgo.Record{
+				// queue the message for producing in batch
+				select {
+				case <-ctx.Done():
+					r.logger.Debug("context cancelled; exiting relay")
+					close(r.producerBatchCh)
+					break pollLoop
+				case r.producerBatchCh <- &kgo.Record{
 					Key:       rec.Key,
 					Value:     rec.Value,
 					Topic:     t, // remap destination topic
 					Partition: rec.Partition,
+				}:
+					// default:
+					// 	r.logger.Debug("producer batch channel full")
 				}
-
-				r.metrics.GetOrCreateCounter(fmt.Sprintf(RelayMetric, rec.Topic, t, rec.Partition)).Inc()
-
-				r.logger.Debug("producing message", "broker", r.producer.client.OptValue(kgo.SeedBrokers), "msg", msg)
-
-				// Async producer which internally batches the messages as per producer `batch_size`
-				r.producer.client.Produce(ctx, msg, func(rec *kgo.Record, err error) {
-					if err != nil {
-						r.logger.Error("error producing message", "err", err)
-						return
-					}
-
-					r.consumerMgr.setTopicOffsets(rec)
-				})
 			}
 		}
 	}
 
-	wg.Wait()
+	return nil
+}
+
+// startProducerWorker starts producer worker which flushes the producer batch at a given frequency.
+func (r *relay) startProducerWorker(ctx context.Context, wg *sync.WaitGroup) error {
+	tick := time.NewTicker(r.producer.cfg.FlushFrequency)
+	defer tick.Stop()
+	defer wg.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// reset
+			r.producerBatch = r.producerBatch[:0]
+			return ctx.Err()
+
+		// enqueue the message to the producer batch and flush if batch size is reached.
+		case msg, ok := <-r.producerBatchCh:
+
+			// cleanup; close the producer batch channel and flush the remaining messages
+			if !ok {
+				now := time.Now()
+				ct := 0
+				// ignore other messages; we can fetch the produced offsets from producer topics and start from there on boot.
+				for range r.producerBatchCh {
+					ct++
+				}
+
+				r.logger.Debug("flushing producer batch", "elapsed", time.Since(now), "count", ct)
+				return nil
+			}
+
+			r.producerBatch = append(r.producerBatch, msg)
+
+			if len(r.producerBatch) >= r.producer.cfg.FlushBatchSize {
+				if err := r.flushProducer(ctx); err != nil {
+					return err
+				}
+
+				tick.Reset(r.producer.cfg.FlushFrequency)
+			}
+
+		// flush the producer batch at a given frequency.
+		case <-tick.C:
+			if len(r.producerBatch) > 0 {
+				if err := r.flushProducer(ctx); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+// flushProducer flushes the producer batch to kafka and updates the topic offsets.
+func (r *relay) flushProducer(ctx context.Context) error {
+	var (
+		retries = 0
+		sent    bool
+		backOff = retryBackoff()
+	)
+
+	saveOffsetsFor := func(recs []*kgo.Record) {
+		// set the topic offset for records that were successfully produced
+		r.consumerMgr.Lock()
+		for i := 0; i < len(recs); i++ {
+			r.consumerMgr.setTopicOffsets(recs[i])
+		}
+		r.consumerMgr.Unlock()
+	}
+
+retry:
+	for retries < r.producer.cfg.MaxRetries {
+		batchLen := len(r.producerBatch)
+
+		r.logger.Info("producing message", "broker", r.producer.client.OptValue(kgo.SeedBrokers), "msgs", batchLen, "retry", retries)
+		results := r.producer.client.ProduceSync(ctx, r.producerBatch...)
+
+		// Check for error and use that to identify what messages failed to produce.
+		var (
+			err       error
+			failures  []*kgo.Record
+			successes []*kgo.Record
+		)
+		for _, res := range results {
+			// exit if context is cancelled
+			if res.Err == context.Canceled {
+				return ctx.Err()
+			}
+
+			if res.Err != nil {
+				failures = append(failures, res.Record)
+				r.logger.Error("error producing message results", "err", res.Err)
+				err = res.Err
+				continue
+			}
+
+			successes = append(successes, res.Record)
+			var (
+				srcTopic  = res.Record.Topic
+				destTopic = r.topics[res.Record.Topic]
+				p         = res.Record.Partition
+			)
+			r.metrics.GetOrCreateCounter(fmt.Sprintf(RelayMetric, srcTopic, destTopic, p)).Inc()
+		}
+
+		// retry if there is an error
+		if err != nil {
+			r.logger.Error("error producing message", "err", err, "failed_count", batchLen, "retry", retries)
+
+			// save offsets for all successfull messages
+			saveOffsetsFor(successes)
+
+			// reset the batch to the failed messages
+			r.producerBatch = failures
+			retries++
+
+			// backoff retry
+			b := backOff(retries)
+			r.logger.Debug("error producing message; waiting for retry...", "backoff", b.Seconds())
+			waitTries(ctx, b)
+
+			continue retry
+		}
+
+		// save offsets for all successfull messages
+		saveOffsetsFor(successes)
+
+		// reset the batch to the remaining messages
+		r.producerBatch = r.producerBatch[batchLen:]
+		sent = true
+		break retry
+	}
+
+	if !sent {
+		return fmt.Errorf("error producing message; exhausted retries (%v)", r.producer.cfg.MaxRetries)
+	}
 
 	return nil
 }
@@ -280,10 +438,12 @@ loop:
 				}
 
 				if currOffsets != nil && thresholdExceeded(of, currOffsets, r.lagThreshold) {
+					// setup method locks consumer manager
 					setup := func() {
 						atomic.CompareAndSwapUint32(&r.consumerMgr.reconnectInProgress, StateDisconnected, StateConnecting)
 						r.consumerMgr.Lock()
 					}
+					// cleanup method unlocks the consumer manager
 					cleanup := func() {
 						r.consumerMgr.Unlock()
 						atomic.CompareAndSwapUint32(&r.consumerMgr.reconnectInProgress, StateConnecting, StateDisconnected)
@@ -294,8 +454,10 @@ loop:
 					addrs := r.consumerMgr.getClient(idx).OptValue(kgo.SeedBrokers)
 					r.logger.Debug("lag threshold exceeded; switching over", "broker", addrs)
 
+					// set index to 1 less than the index we are going to increment inside `connectToNextNode`
 					r.consumerMgr.setActive(idx - 1)
 					if err := r.consumerMgr.connectToNextNode(); err != nil {
+						// reset the index back to original on error
 						r.consumerMgr.setActive(curr)
 						cleanup()
 						continue lagCheck
@@ -334,11 +496,6 @@ func (r *relay) validateOffsets(ctx context.Context) error {
 		return err
 	}
 
-	commitOffsets, err := getCommittedOffsets(ctx, c, consTopics)
-	if err != nil {
-		return err
-	}
-
 	for _, ps := range consOffsets {
 		for _, o := range ps {
 			// store the end offsets
@@ -364,16 +521,9 @@ func (r *relay) validateOffsets(ctx context.Context) error {
 			}
 
 			// Confirm that committed offsets of consumer group matches the offsets of destination kafka topic partition
-			if destOffset.Offset > 0 {
-				o, ok := commitOffsets.Lookup(o.Topic, destOffset.Partition)
-				if !ok {
-					return fmt.Errorf("error finding topic, partition for %v in source kafka", o.Topic)
-				}
-
-				if destOffset.Offset > o.Offset {
-					return fmt.Errorf("destination topic(%v), partition(%v) offsets(%v) is higher than consumer group committed offsets(%v)",
-						destOffset.Topic, destOffset.Partition, destOffset.Offset, o.Offset)
-				}
+			if destOffset.Offset > o.Offset {
+				return fmt.Errorf("destination topic(%v), partition(%v) offsets(%v) is higher than consumer group committed offsets(%v)",
+					destOffset.Topic, destOffset.Partition, destOffset.Offset, o.Offset)
 			}
 		}
 	}


### PR DESCRIPTION
* Async doesn't give us control on what is produced and what batch is failed. By taking control of this batching using sync producer in another goroutine, we will know what messages are produced, attempt retry and exit on max retries