### PR TITLE
fix: Remap producer offset topic -> consumer topic for resetting offsets

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,8 +114,6 @@ func main() {
 		log.Fatalf("error fetching destination offsets: %v", err)
 	}
 
-	offsetMgr := &offsetManager{Offsets: destOffsets.KOffsets()}
-
 	// setup consumer hook, consumer
 	var n = make([]Node, len(cfg.Consumers))
 	for i := 0; i < len(cfg.Consumers); i++ {
@@ -130,7 +128,7 @@ func main() {
 		cfgs:        cfg.Consumers,
 		maxReqTime:  cfg.App.MaxRequestDuration,
 		backoffCfg:  cfg.App.Backoff,
-		offsetMgr:   offsetMgr,
+		offsets:     destOffsets.KOffsets(),
 		nodeTracker: NewNodeTracker(n),
 		l:           logger,
 	}

--- a/main.go
+++ b/main.go
@@ -82,14 +82,14 @@ func main() {
 	}
 
 	// Assign topic mapping
-	var topics []string
-	for t := range cfg.Topics {
-		topics = append(topics, t)
+	var consumerTopics []string
+	for c := range cfg.Topics {
+		consumerTopics = append(consumerTopics, c)
 	}
 
 	// Set consumer topics
 	for i := 0; i < len(cfg.Consumers); i++ {
-		cfg.Consumers[i].Topics = topics
+		cfg.Consumers[i].Topics = consumerTopics
 	}
 	cfg.Producer.Topics = cfg.Topics
 
@@ -109,14 +109,14 @@ func main() {
 	prod.maxReqTime = cfg.App.MaxRequestDuration
 
 	// setup offsets manager with the destination offsets
-	destOffsets, err := prod.GetEndOffsets(ctx, cfg.App.MaxRequestDuration)
+	destOffsets, err := prod.getOffsetsForConsumer(ctx, cfg.App.MaxRequestDuration)
 	if err != nil {
 		log.Fatalf("error fetching destination offsets: %v", err)
 	}
+
 	offsetMgr := &offsetManager{Offsets: destOffsets.KOffsets()}
 
 	// setup consumer hook, consumer
-	hookCh := make(chan struct{}, 1)
 	var n = make([]Node, len(cfg.Consumers))
 	for i := 0; i < len(cfg.Consumers); i++ {
 		n[i] = Node{
@@ -140,7 +140,7 @@ func main() {
 		consumer: cons,
 		producer: prod,
 
-		unhealthyCh: hookCh,
+		unhealthyCh: make(chan struct{}, 1),
 
 		topics:  cfg.Topics,
 		metrics: metr,
@@ -158,8 +158,6 @@ func main() {
 		destOffsets: destOffsets.KOffsets(),
 
 		filters: filters,
-
-		nodeCh: make(chan int, 1),
 	}
 
 	// Start metrics handler

--- a/relay.go
+++ b/relay.go
@@ -47,7 +47,6 @@ type relay struct {
 
 	// signal to cancel the poll loop context
 	// use this to track the current node id in track topic lag
-	nodeCh     chan int
 	pollCancel context.CancelFunc
 }
 

--- a/utils.go
+++ b/utils.go
@@ -340,8 +340,14 @@ func retryBackoff(min, max time.Duration) func(int) time.Duration {
 
 // waitTries waits for the timer to hit for the deadline with the backoff duration
 func waitTries(ctx context.Context, b time.Duration) {
+	if b == 0 {
+		return
+	}
+
 	deadline := time.Now().Add(b)
 	after := time.NewTimer(time.Until(deadline))
+	defer after.Stop()
+
 	select {
 	case <-ctx.Done():
 		return


### PR DESCRIPTION
* remap producer topic -> consumer topic when we restart the program
* stop timers to prevent leak
* reduce map alloc while recording offsets
* reuse *kgo.Record from consumer and repurpose when we are forwarding into producer rather than allocating new rec obj