### PR TITLE
Review fixes in `pkg` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ func (r *RedisTarget) Close() error {
 Connect it to the relay.
 
 ```go
-target := NewRedisTarget("localhost:6379", log)
+target := NewRedisTarget("localhost:6379", "my-stream", log)
 
 srcPool, _ := relay.NewSourcePool(poolCfg, consumerCfgs, topic, nil, metricsSet, log)
 

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 			// Start the relay. This is an indefinitely blocking call.
 			defer wg.Done()
 
-			target, err := kafkatarget.New(initTargetConfig(ko), prodConfig, topics, globalCtx, metr, lo)
+			target, err := kafkatarget.New(globalCtx, initTargetConfig(ko), prodConfig, topics, metr, lo)
 			if err != nil {
 				log.Fatalf("error initializing target controller: %v", err)
 			}

--- a/pkg/kafkatarget/kafkatarget.go
+++ b/pkg/kafkatarget/kafkatarget.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/VictoriaMetrics/metrics"
@@ -28,11 +29,11 @@ type targetMetrics struct {
 
 func newTargetMetrics(set *metrics.Set) targetMetrics {
 	return targetMetrics{
-		networkErrClientCreation: set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetErrors, "error", relay.ErrLabelClientCreation)),
-		networkErrConnection:     set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetErrors, "error", relay.ErrLabelProducerConnection)),
-		kafkaErrTLS:              set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetKafkaErrors, "error", relay.ErrLabelTLSConfig)),
-		kafkaErrProduce:          set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetKafkaErrors, "error", relay.ErrLabelProduce)),
-		kafkaErrProduceRetries:   set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetKafkaErrors, "error", relay.ErrLabelProduceRetries)),
+		networkErrClientCreation: set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetErrors, relay.Label{Key: "error", Value: relay.ErrLabelClientCreation})),
+		networkErrConnection:     set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetErrors, relay.Label{Key: "error", Value: relay.ErrLabelProducerConnection})),
+		kafkaErrTLS:              set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetKafkaErrors, relay.Label{Key: "error", Value: relay.ErrLabelTLSConfig})),
+		kafkaErrProduce:          set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetKafkaErrors, relay.Label{Key: "error", Value: relay.ErrLabelProduce})),
+		kafkaErrProduceRetries:   set.GetOrCreateCounter(relay.MetricName(relay.MetricTargetKafkaErrors, relay.Label{Key: "error", Value: relay.ErrLabelProduceRetries})),
 		flushBatchSize:           set.GetOrCreateHistogram(relay.MetricName(relay.MetricFlushBatchSize)),
 		flushDuration:            set.GetOrCreateHistogram(relay.MetricName(relay.MetricFlushDuration)),
 		flushRetries:             set.GetOrCreateCounter(relay.MetricName(relay.MetricFlushRetries)),
@@ -45,7 +46,6 @@ type Target struct {
 	client *kgo.Client
 	cfg    relay.TargetCfg
 	pCfg   relay.ProducerCfg
-	ctx    context.Context
 	metr   targetMetrics
 	log    *slog.Logger
 
@@ -59,15 +59,17 @@ type Target struct {
 
 	// doneCh is closed when Start() returns, so Close() can wait for drain.
 	doneCh chan struct{}
+
+	closeOnce sync.Once
 }
 
 // New creates a new Kafka target that implements relay.Target.
 // It connects to the target Kafka cluster and validates that all target topics exist.
-func New(cfg relay.TargetCfg, pCfg relay.ProducerCfg, topics relay.Topics, ctx context.Context, m *metrics.Set, log *slog.Logger) (*Target, error) {
+// The provided ctx controls cancellation of the initial connection/retry loop.
+func New(ctx context.Context, cfg relay.TargetCfg, pCfg relay.ProducerCfg, topics relay.Topics, m *metrics.Set, log *slog.Logger) (*Target, error) {
 	tg := &Target{
 		cfg:    cfg,
 		pCfg:   pCfg,
-		ctx:    ctx,
 		metr:   newTargetMetrics(m),
 		log:    log,
 		topics: topics,
@@ -77,7 +79,7 @@ func New(cfg relay.TargetCfg, pCfg relay.ProducerCfg, topics relay.Topics, ctx c
 		doneCh:  make(chan struct{}),
 	}
 
-	cl, err := tg.initProducer(topics)
+	cl, err := tg.initProducer(ctx, topics)
 	if err != nil {
 		return nil, err
 	}
@@ -209,8 +211,11 @@ func (tg *Target) Write(ctx context.Context, msg relay.Message) error {
 
 // Close signals the target to stop accepting new messages, drain
 // any buffered messages, and shut down. Blocks until Start() returns.
+// Safe to call multiple times; only the first call has effect.
 func (tg *Target) Close() error {
-	close(tg.inletCh)
+	tg.closeOnce.Do(func() {
+		close(tg.inletCh)
+	})
 
 	// Wait for Start() to finish draining.
 	<-tg.doneCh
@@ -223,7 +228,7 @@ func (tg *Target) Close() error {
 }
 
 // initProducer creates the Kafka producer client with retries.
-func (tg *Target) initProducer(top relay.Topics) (*kgo.Client, error) {
+func (tg *Target) initProducer(ctx context.Context, top relay.Topics) (*kgo.Client, error) {
 	opts := []kgo.Opt{
 		kgo.ProduceRequestTimeout(tg.pCfg.SessionTimeout),
 		kgo.RecordDeliveryTimeout(tg.pCfg.SessionTimeout),
@@ -270,7 +275,7 @@ func (tg *Target) initProducer(top relay.Topics) (*kgo.Client, error) {
 outerLoop:
 	for retries < tg.pCfg.MaxRetries || tg.pCfg.MaxRetries == relay.IndefiniteRetry {
 		select {
-		case <-tg.ctx.Done():
+		case <-ctx.Done():
 			break outerLoop
 		default:
 			cl, err = kgo.NewClient(opts...)
@@ -278,7 +283,7 @@ outerLoop:
 				tg.metr.networkErrClientCreation.Inc()
 				tg.log.Error("error creating producer client", "error", err)
 				retries++
-				relay.WaitTries(tg.ctx, backoff(retries))
+				relay.WaitTries(ctx, backoff(retries))
 				continue
 			}
 
@@ -301,7 +306,7 @@ outerLoop:
 				tg.metr.networkErrConnection.Inc()
 				tg.log.Error("error connecting to producer", "err", err)
 				retries++
-				relay.WaitTries(tg.ctx, backoff(retries))
+				relay.WaitTries(ctx, backoff(retries))
 				continue
 			}
 
@@ -316,7 +321,7 @@ outerLoop:
 	return cl, nil
 }
 
-// drain drains and flushes any pending messages in the producer.
+// drain drains any remaining buffered messages from inletCh and flushes the batch.
 func (tg *Target) drain() error {
 	now := time.Now()
 	for rec := range tg.inletCh {

--- a/pkg/relay/common.go
+++ b/pkg/relay/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -56,12 +57,17 @@ const (
 )
 
 var (
-	ErrLaggingBehind = fmt.Errorf("topic end offset is lagging behind")
+	ErrLaggingBehind = errors.New("topic end offset is lagging behind")
 )
 
-// MetricName builds a Prometheus metric name with optional key=value label pairs.
-// E.g. MetricName("errors_total", "node_id", "1") → `kafka_relay_errors_total{node_id="1"}`
-func MetricName(base string, labels ...string) string {
+// Label is a key-value pair for Prometheus metric labels.
+type Label struct {
+	Key, Value string
+}
+
+// MetricName builds a Prometheus metric name with optional labels.
+// E.g. MetricName("errors_total", Label{"node_id", "1"}) → `kafka_relay_errors_total{node_id="1"}`
+func MetricName(base string, labels ...Label) string {
 	if len(labels) == 0 {
 		return RelayMetricPrefix + base
 	}
@@ -70,13 +76,13 @@ func MetricName(base string, labels ...string) string {
 	b.WriteString(RelayMetricPrefix)
 	b.WriteString(base)
 	b.WriteByte('{')
-	for i := 0; i < len(labels); i += 2 {
+	for i, l := range labels {
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		b.WriteString(labels[i])
+		b.WriteString(l.Key)
 		b.WriteString(`="`)
-		b.WriteString(labels[i+1])
+		b.WriteString(l.Value)
 		b.WriteByte('"')
 	}
 	b.WriteByte('}')

--- a/pkg/relay/common.go
+++ b/pkg/relay/common.go
@@ -22,10 +22,10 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 )
 
-const RelayMetricPrefix = "kafka_relay_"
-
-// Metric names. Target{} implementations should use these to emit metrics.
 const (
+	RelayMetricPrefix = "kafka_relay_"
+
+	// Metric names. Target{} implementations should use these to emit metrics.
 	MetricSourceErrors      = "source_errors_total"
 	MetricSourceUnhealthy   = "source_unhealthy_total"
 	MetricSourceKafkaErrors = "source_kafka_errors_total"
@@ -42,10 +42,8 @@ const (
 	MetricCandidateSwitches    = "source_candidate_switches_total"
 	MetricSourceConnections    = "source_connections_total"
 	MetricLagThresholdExceeded = "source_lag_threshold_exceeded_total"
-)
 
-// Canonical error labels for metrics.
-const (
+	// Canonical error labels for metrics.
 	ErrLabelConnectionFailed   = "connection_failed"
 	ErrLabelClientClosed       = "client_closed"
 	ErrLabelFetch              = "fetch_error"
@@ -54,16 +52,32 @@ const (
 	ErrLabelProducerConnection = "connection_failed"
 	ErrLabelProduce            = "produce_failed"
 	ErrLabelProduceRetries     = "produce_retries_exhausted"
+
+	// SASL mechanisms.
+	SASLMechanismPlain       = "PLAIN"
+	SASLMechanismScramSHA256 = "SCRAM-SHA-256"
+	SASLMechanismScramSHA512 = "SCRAM-SHA-512"
+
+	// Relay modes.
+	ModeFailover    = "failover"
+	ModeSingle      = "single"
+	IndefiniteRetry = -1
 )
 
-var (
-	ErrLaggingBehind = errors.New("topic end offset is lagging behind")
+// Connection states (iota-based, must stay in a separate block).
+const (
+	StateDisconnected = iota
+	StateConnecting
 )
 
 // Label is a key-value pair for Prometheus metric labels.
 type Label struct {
 	Key, Value string
 }
+
+var (
+	ErrLaggingBehind = errors.New("topic end offset is lagging behind")
+)
 
 // MetricName builds a Prometheus metric name with optional labels.
 // E.g. MetricName("errors_total", Label{"node_id", "1"}) → `kafka_relay_errors_total{node_id="1"}`
@@ -89,23 +103,6 @@ func MetricName(base string, labels ...Label) string {
 
 	return b.String()
 }
-
-const (
-	SASLMechanismPlain       = "PLAIN"
-	SASLMechanismScramSHA256 = "SCRAM-SHA-256"
-	SASLMechanismScramSHA512 = "SCRAM-SHA-512"
-)
-
-const (
-	ModeFailover    = "failover"
-	ModeSingle      = "single"
-	IndefiniteRetry = -1
-)
-
-const (
-	StateDisconnected = iota
-	StateConnecting
-)
 
 func GetCompressionCodec(codec string) kgo.CompressionCodec {
 	switch codec {

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -52,10 +52,10 @@ func (rm *relayMetrics) incRelayed(srcTopic string, srcPartition int32, tgtTopic
 	c, ok = rm.relayed[key]
 	if !ok {
 		c = rm.set.GetOrCreateCounter(MetricName(MetricMsgsRelayed,
-			"source_topic", srcTopic,
-			"source_partition", strconv.Itoa(int(srcPartition)),
-			"target_topic", tgtTopic,
-			"target_partition", strconv.Itoa(int(tgtPartition)),
+			Label{"source_topic", srcTopic},
+			Label{"source_partition", strconv.Itoa(int(srcPartition))},
+			Label{"target_topic", tgtTopic},
+			Label{"target_partition", strconv.Itoa(int(tgtPartition))},
 		))
 		rm.relayed[key] = c
 	}
@@ -308,7 +308,7 @@ func (re *Relay) processMessage(ctx context.Context, rec *kgo.Record) error {
 		for n, f := range re.filters {
 			if !f.IsAllowed(rec.Value) {
 				re.log.Debug("filtering message", "message", string(rec.Value), "filter", n)
-				re.metrics.GetOrCreateCounter(MetricName(MetricFilteredMsgs, "filter", n)).Inc()
+				re.metrics.GetOrCreateCounter(MetricName(MetricFilteredMsgs, Label{"filter", n})).Inc()
 				ok = false
 				break
 			}

--- a/pkg/relay/source_pool.go
+++ b/pkg/relay/source_pool.go
@@ -39,12 +39,12 @@ func newSourceMetrics(set *metrics.Set, servers []Server) sourceMetrics {
 	for _, s := range servers {
 		id := strconv.Itoa(s.ID)
 		sm.nodes[s.ID] = &sourceNodeMetrics{
-			networkErrConnFailed: set.GetOrCreateCounter(MetricName(MetricSourceErrors, "node_id", id, "error", ErrLabelConnectionFailed)),
-			kafkaErrClientClosed: set.GetOrCreateCounter(MetricName(MetricSourceKafkaErrors, "node_id", id, "error", ErrLabelClientClosed)),
-			kafkaErrFetch:        set.GetOrCreateCounter(MetricName(MetricSourceKafkaErrors, "node_id", id, "error", ErrLabelFetch)),
-			highwatermark:        set.GetOrCreateGauge(MetricName(MetricSourceHighwater, "node_id", id), nil),
-			connections:          set.GetOrCreateCounter(MetricName(MetricSourceConnections, "node_id", id)),
-			lagThresholdExceeded: set.GetOrCreateCounter(MetricName(MetricLagThresholdExceeded, "node_id", id)),
+			networkErrConnFailed: set.GetOrCreateCounter(MetricName(MetricSourceErrors, Label{"node_id", id}, Label{"error", ErrLabelConnectionFailed})),
+			kafkaErrClientClosed: set.GetOrCreateCounter(MetricName(MetricSourceKafkaErrors, Label{"node_id", id}, Label{"error", ErrLabelClientClosed})),
+			kafkaErrFetch:        set.GetOrCreateCounter(MetricName(MetricSourceKafkaErrors, Label{"node_id", id}, Label{"error", ErrLabelFetch})),
+			highwatermark:        set.GetOrCreateGauge(MetricName(MetricSourceHighwater, Label{"node_id", id}), nil),
+			connections:          set.GetOrCreateCounter(MetricName(MetricSourceConnections, Label{"node_id", id})),
+			lagThresholdExceeded: set.GetOrCreateCounter(MetricName(MetricLagThresholdExceeded, Label{"node_id", id})),
 		}
 	}
 	return sm


### PR DESCRIPTION
- Move ctx to first parameter in kafkatarget.New (Go convention)
- Remove stored context.Context from Target struct; pass to initProducer
- Protect Close() against double-call with sync.Once
- Guard MetricName with Label struct for compile-time safe key-value pairs
- Use errors.New for static ErrLaggingBehind
- Fix README RedisTarget example missing topic argument